### PR TITLE
Enforce documented dimension invariant in TooDee::new

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -76,6 +76,18 @@ mod toodee_tests {
     }
 
     #[test]
+    #[should_panic]
+    fn new_bad_dimensions() {
+        let _ : TooDee<u32> = TooDee::new(0, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn new_bad_dimensions_2() {
+        let _ : TooDee<u32> = TooDee::new(1, 0);
+    }
+
+    #[test]
     fn new_view() {
         let toodee : TooDee<u32> = TooDee::new(200, 150);
         let view = toodee.view((50, 50), (150, 100));

--- a/src/toodee.rs
+++ b/src/toodee.rs
@@ -418,6 +418,9 @@ impl<T> TooDee<T> {
     /// ```
     pub fn new(num_cols: usize, num_rows: usize) -> TooDee<T>
     where T: Default {
+        if num_cols == 0 || num_rows == 0 {
+            assert_eq!(num_rows, num_cols);
+        }
         let mut data = Vec::new();
         data.resize_with(num_cols.checked_mul(num_rows).unwrap(), T::default);
         TooDee { data, num_cols, num_rows }


### PR DESCRIPTION
Fixes #30.

`TooDee::new` is documented to panic when one dimension is zero but the other is non-zero, but it skipped that check, so `TooDee::new(0, 1)` silently built a value that violates the empty-array invariant. `init` and `from_vec` already enforce this, so this adds the same guard to `new` plus two regression tests.